### PR TITLE
Ignore within Markdown links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ defined in `LICENSE`.
 
 ## Change Log
 
+### Dev Version
+
+Ignore mentions/issues/commits within Markdown links.
+
 ### Version 0.1 (2017/11/10)
 
 The initial release.

--- a/mdx_gh_links.py
+++ b/mdx_gh_links.py
@@ -52,6 +52,8 @@ def _build_link(label, title, href, classes):
 
 
 class MentionPattern(Pattern):
+    ANCESTOR_EXCLUDES = ('a',)
+
     def __init__(self, config, md):
         MENTION_RE = r'(@({USER})(?:\/({REPO}))?)'.format(**RE_PARTS)
         super(MentionPattern, self).__init__(MENTION_RE, md)
@@ -71,6 +73,8 @@ class MentionPattern(Pattern):
 
 
 class IssuePattern(Pattern):
+    ANCESTOR_EXCLUDES = ('a',)
+
     def __init__(self, config, md):
         ISSUE_RE = r'((?:({USER})\/({REPO}))?#([0-9]+))'.format(**RE_PARTS)
         super(IssuePattern, self).__init__(ISSUE_RE, md)
@@ -87,6 +91,8 @@ class IssuePattern(Pattern):
 
 
 class CommitPattern(Pattern):
+    ANCESTOR_EXCLUDES = ('a',)
+
     def __init__(self, config, md):
         COMMIT_RE = r'((?:({USER})(?:\/({REPO}))?@|\b)([a-f0-9]{{40}})\b)'.format(**RE_PARTS)
         super(CommitPattern, self).__init__(COMMIT_RE, md)
@@ -122,5 +128,5 @@ class GithubLinks(Extension):
         md.inlinePatterns['commit'] = CommitPattern(self.getConfigs(), md)
 
 
-def makeExtension(*args, **kwargs):
+def makeExtension(*args, **kwargs):  # pragma: no cover
     return GithubLinks(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     url='https://github.com/Python-Markdown/github-links/',
     license='BSD License',
     py_modules=['mdx_gh_links'],
-    install_requires=['markdown>=2.5'],
+    install_requires=['markdown>=2.6.11'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: BSD License',

--- a/test_gh_links.py
+++ b/test_gh_links.py
@@ -102,6 +102,12 @@ class TestGithubLinks(unittest.TestCase):
             '<p>Issue Organization/Repo#123.</p>',
         )
 
+    def test_issue_in_link(self):
+        self.assertMarkdownRenders(
+            '[Issue #123](#).',
+            '<p><a href="#">Issue #123</a>.</p>',
+        )
+
     # Mention Tests
     def test_mention_user(self):
         self.assertMarkdownRenders(
@@ -147,6 +153,12 @@ class TestGithubLinks(unittest.TestCase):
             '<p>User @foo/bar.</p>',
         )
 
+    def test_mention_in_link(self):
+        self.assertMarkdownRenders(
+            'User [@foo](#).',
+            '<p>User <a href="#">@foo</a>.</p>',
+        )
+
     # Commit Tests
     def test_commit(self):
         self.assertMarkdownRenders(
@@ -177,6 +189,12 @@ class TestGithubLinks(unittest.TestCase):
         self.assertMarkdownRenders(
             'Commit `83fb46b3b7ab8ad4316681fc4637c521da265f1d`.',
             '<p>Commit <code>83fb46b3b7ab8ad4316681fc4637c521da265f1d</code>.</p>',
+        )
+
+    def test_commit_in_link(self):
+        self.assertMarkdownRenders(
+            'Commit [83fb46b3b7ab8ad4316681fc4637c521da265f1d](#).',
+            '<p>Commit <a href="#">83fb46b3b7ab8ad4316681fc4637c521da265f1d</a>.</p>',
         )
 
 


### PR DESCRIPTION
Uses Markdown Patterns' new `ANCESTOR_EXCLUDES`.