### PR TITLE
Upgrade GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,16 +3,15 @@ name: deploy
 on:
   push:
     tags:
-    - '*'
+      - "*"
 
 jobs:
-
   pypi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name: Install dependencies
@@ -23,7 +22,7 @@ jobs:
           python -m build
       - name: Publish
         if: success()
-        uses: pypa/gh-action-pypi-publish@v1.1.0
+        uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   pull_request:
     branches:
-    - '**'
+      - "**"
 
 jobs:
   test:
@@ -11,38 +11,39 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, pypy-3.8, pypy-3.9, pypy-3.10]
+        python-version:
+          ["3.8", "3.9", "3.10", "3.11", "pypy-3.8", "pypy-3.9", "pypy-3.10"]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip coverage markdown
-    - name: Run tests
-      run: |
-        coverage run test_gh_links.py
-    - name: Generate coverage report
-      if: success()
-      run: |
-        coverage xml
-        coverage report --show-missing --include=mdx_gh_links.py
-    - name: Upload Results
-      if: success()
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: ${{ matrix.os }}/Python ${{ matrix.python-version }}
-        fail_ci_if_error: false
+      - uses: actions/checkout@v4
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip coverage markdown
+      - name: Run tests
+        run: |
+          coverage run test_gh_links.py
+      - name: Generate coverage report
+        if: success()
+        run: |
+          coverage xml
+          coverage report --show-missing --include=mdx_gh_links.py
+      - name: Upload Results
+        if: success()
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.xml
+          flags: unittests
+          name: ${{ matrix.os }}/Python ${{ matrix.python-version }}
+          fail_ci_if_error: false
 
   flake8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: TrueBrain/actions-flake8@master
         with:
           max_line_length: 118
@@ -50,8 +51,8 @@ jobs:
   mdlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: DavidAnson/markdownlint-cli2-action@v11
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v14
         with:
-          config: '.markdownlint.jsonc'
-          globs: '**/*.md'
+          config: ".markdownlint.jsonc"
+          globs: "**/*.md"


### PR DESCRIPTION
Hi,
I just discovered this interesting project. I noticed that the GitHub Actions used in the CI workflows are **outdated** since a while.

Due to the use of the outdated Node.js version **12** some will break eventually.

![Screenshot of actions warnings](https://github.com/Python-Markdown/github-links/assets/72736591/de137920-30f5-4b66-8c58-ad5ba8b63f90)

I **upgraded** the GitHub Actions to the latest versions.

I also noticed that the GitHub **host** is harcoded in:

https://github.com/Python-Markdown/github-links/blob/5bc28d3f25420fdba74ce9b20a868c6f3d0ea458/mdx_gh_links.py#L38

Therefore usage on **GitHub Enterprise Servers** (GHES) is currently unfortunately **not** possible. Adding a new config item might fix it.

https://github.com/Python-Markdown/github-links/blob/5bc28d3f25420fdba74ce9b20a868c6f3d0ea458/mdx_gh_links.py#L119-L120

```python
    'hostname': ['github.com', 'GitHub Enterprise Server hostname.']
```

The **hostname** would be parsed afterwards and used in [`URL_BASE`](https://github.com/Python-Markdown/github-links/blob/5bc28d3f25420fdba74ce9b20a868c6f3d0ea458/mdx_gh_links.py#L38).